### PR TITLE
Added Anthony Cox and Ivor Caldwell

### DIFF
--- a/ISO-27001/README.md
+++ b/ISO-27001/README.md
@@ -55,8 +55,8 @@ Group Members:
 * Digital Delivery Director - Neil Dunlop
 * Technical Directors:
   * Leeds - Ed Marshall
-  * London - Neil Dunlop
-  * Manchester - Rick Boyce
+  * London - Anthony Cox
+  * Manchester - Ivor Caldwell (Interim)
   * Edinburgh - Ed Marshall
 * Director of People - Charlotte Goulding
 * Director of Talent Acquisition - Jen Riley


### PR DESCRIPTION
As TDs for London and Manchester respectively.